### PR TITLE
Fixed crashing on 'File->Archive Completed Tasks'

### DIFF
--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -393,6 +393,9 @@ Copyright 2011 Ben Hughes";
             if (!File.Exists(User.Default.ArchiveFilePath))
                 File_Select_Archive_File(this, null);
 
+            if (!File.Exists(User.Default.ArchiveFilePath))
+                return;
+
             var archiveList = new TaskList(User.Default.ArchiveFilePath);
             var completed = _taskList.Tasks.Where(t => t.Completed);
             foreach (var task in completed)


### PR DESCRIPTION
Fixed crashing when 'File->Archive Completed Tasks' is executed and no file is selected.
