### PR TITLE
Dev

### DIFF
--- a/Client/MainWindow.xaml
+++ b/Client/MainWindow.xaml
@@ -58,10 +58,6 @@
                     </StackPanel>
                 </DataTemplate>
             </ListBox.ItemTemplate>
-            <ListBox.Resources>
-                <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="{DynamicResource {x:Static SystemColors.HighlightColorKey}}" />
-                <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="{DynamicResource {x:Static SystemColors.HighlightColorKey}}" />
-            </ListBox.Resources>
         </ListBox>
         <WebBrowser Height="Auto" HorizontalAlignment="Stretch" Margin="0,46,0,0" Name="webBrowser1" VerticalAlignment="Stretch" Width="Auto" Visibility="Hidden" Grid.ColumnSpan="2" />
         <Button Content="PRINT" Height="23" HorizontalAlignment="Left" Margin="0,23,207,0" Name="btnPrint" VerticalAlignment="Top" Width="92" Visibility="Hidden" Click="btnPrint_Click" />


### PR DESCRIPTION
Reverting the last commit (_"Changed tasks list box to retain selection highlight when losing focus, so that the selected item is more apparent when deleting a task."_), which introduced a bug (a blue square displayed at the junction of the horizontal and vertical scroll bars).

This reverts commit a2a1509bceeb3673171c0c450a6ab475cda017e7.
