### PR TITLE
Set focus on Print Preview Cancel button click.

### DIFF
--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -491,6 +491,7 @@ namespace Client
 		private void btnCancelPrint_Click(object sender, RoutedEventArgs e)
 		{
 			Set_PrintControlsVisibility(false);
+            taskText.Focus();
 		}
 
 		private void Set_PrintControlsVisibility(bool PrintControlsVisibility)


### PR DESCRIPTION
I updated the Cancel button on the Print Preview to focus back on the
main form.  The problem was that if the cancel button was clicked the
main form didn't have focus so the hot keys didn't work.  You had to
click in the main text box to get the focus again.  This behavior caused
some automation software not to work well after a print preview was
done.
