### PR TITLE
Fixed layout of Filter dialog text

### DIFF
--- a/Client/FilterDialog.xaml
+++ b/Client/FilterDialog.xaml
@@ -7,7 +7,8 @@
 			<RowDefinition Height="444*" />
 			<RowDefinition Height="14*" />
 		</Grid.RowDefinitions>
-		<Label Content="To invoke a filter from the main window, press '1', '2' or '3'.  '0' to clear." Height="28" HorizontalAlignment="Left" Margin="1,7,0,0" Name="label1" VerticalAlignment="Top" Width="370" />
+		<Label Content="To invoke a filter from the main window, press '1', '2' or '3'." Height="28" HorizontalAlignment="Left" Margin="1,2,0,0" Name="label1" VerticalAlignment="Top" Width="370" />
+        <Label Content="'0' will clear current active filter." Height="28" HorizontalAlignment="Left" Margin="1,20,0,0" Name="label6" VerticalAlignment="Top" Width="370" />
         <Label Content="Currently active filter:" Height="28" HorizontalAlignment="Left" Margin="0,41,0,0" Name="label2" VerticalAlignment="Top" />
         <TextBox Height="62" Name="tbFilter" VerticalAlignment="Top" AcceptsReturn="True" TextWrapping="Wrap" PreviewKeyUp="tbFilter_PreviewKeyUp" Margin="12,62,12,0" />
         <Label Content="Preset filter #1:" Height="28" HorizontalAlignment="Left" Margin="1,130,0,0" Name="label3" VerticalAlignment="Top" />


### PR DESCRIPTION
Text describing '0' functionality was clipped on some monitors.  Dropped
it to its own line.
