### PR TITLE
Addressed crash in XP for  Issue #117

### DIFF
--- a/Client/User.Designer.cs
+++ b/Client/User.Designer.cs
@@ -253,7 +253,7 @@ namespace Client {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("Segoe UI")]
+        [global::System.Configuration.DefaultSettingValueAttribute("Arial")]
         public string TaskListFontFamily {
             get {
                 return ((string)(this["TaskListFontFamily"]));

--- a/Client/User.settings
+++ b/Client/User.settings
@@ -60,7 +60,7 @@
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="TaskListFontFamily" Type="System.String" Scope="User">
-      <Value Profile="(Default)">Segoe UI</Value>
+      <Value Profile="(Default)">Arial</Value>
     </Setting>
     <Setting Name="TaskListFontSize" Type="System.Double" Scope="User">
       <Value Profile="(Default)">12</Value>

--- a/Client/app.config
+++ b/Client/app.config
@@ -65,7 +65,7 @@
                 <value />
             </setting>
             <setting name="TaskListFontFamily" serializeAs="String">
-                <value>Segoe UI</value>
+                <value>Arial</value>
             </setting>
             <setting name="TaskListFontSize" serializeAs="String">
                 <value>12</value>

--- a/ColorFont/ColorFont.csproj
+++ b/ColorFont/ColorFont.csproj
@@ -100,7 +100,12 @@
     </None>
     <AppDesigner Include="Properties\" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\ToDoLib\ToDoLib.csproj">
+      <Project>{07AA9CEA-4EF0-4B47-AFBD-6F74AD9C4653}</Project>
+      <Name>ToDoLib</Name>
+    </ProjectReference>
+  </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\colorfont_icon.png" />
   </ItemGroup>

--- a/ColorFont/ColorFontDialog.xaml.cs
+++ b/ColorFont/ColorFontDialog.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text;
 using System.Windows;
 using System.Windows.Media;
+using ToDoLib;
 
 namespace ColorFont
 {
@@ -13,6 +14,7 @@ public partial class ColorFontDialog : Window
 
     public ColorFontDialog()
     {
+        Log.Debug("Loading ColorFontDialog");
         this.selectedFont = null; // Default
         InitializeComponent();
     }
@@ -33,29 +35,42 @@ public partial class ColorFontDialog : Window
 
     private void SyncFontName()
     {
+        Log.Debug("In SyncFontName");
+
         string fontFamilyName = this.selectedFont.Family.Source;
+        bool isFontFound = false;
+
         int idx = 0;
         foreach (var item in this.colorFontChooser.lstFamily.Items)
         {
             string itemName = item.ToString();
             if (fontFamilyName == itemName)
             {
+                isFontFound = true;                
                 break;
             }
             idx++;
         }
+        
+        if (!isFontFound)
+        {
+            idx = 0;
+        }
+
         this.colorFontChooser.lstFamily.SelectedIndex = idx;
         this.colorFontChooser.lstFamily.ScrollIntoView(this.colorFontChooser.lstFamily.Items[idx]);
     }
 
     private void SyncFontSize()
     {
+        Log.Debug("In SyncFontSize");
         double fontSize = this.selectedFont.Size;
         this.colorFontChooser.fontSizeSlider.Value = fontSize;
     }
 
     private void SyncFontColor()
     {
+        Log.Debug("In SyncFontColor");
         int colorIdx = AvailableColors.GetFontColorIndex(this.Font.Color);
         this.colorFontChooser.colorPicker.superCombo.SelectedIndex = colorIdx;
         // The following does not work. Why???
@@ -65,6 +80,7 @@ public partial class ColorFontDialog : Window
 
     private void SyncFontTypeface()
     {
+        Log.Debug("In SyncFontTypeface");
         string fontTypeFaceSb = FontInfo.TypefaceToString(this.selectedFont.Typeface);
         int idx = 0;
         foreach (var item in this.colorFontChooser.lstTypefaces.Items)
@@ -87,10 +103,12 @@ public partial class ColorFontDialog : Window
 
     private void Window_Loaded_1(object sender, RoutedEventArgs e)
     {
+        Log.Debug("In Window_Loaded_1" );
         this.SyncFontColor();
         this.SyncFontName();
         this.SyncFontSize();
         this.SyncFontTypeface();
+        Log.Debug("Leaving Window_Loaded_1");
     }
 }
 }


### PR DESCRIPTION
Added limited logging to ColorFontDialog.  Checked to ensure that named
font was found before setting the index value.  Changed default font to
Arial to allow it to function in XP.
