### PR TITLE
A simple fix for #126.

### DIFF
--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -373,6 +373,10 @@ namespace Client
 
 		private void ToggleComplete(Task task)
 		{
+			//Ensure an empty task can not be completed.
+			if(task.Body.Trim() == string.Empty)
+				return;
+
 			var newTask = new Task(task.Raw);
 			newTask.Completed = !newTask.Completed;
 


### PR DESCRIPTION
There probably needs to be a way of informing the user why this can not be completed, perhaps something like the status bar that is mentioned in #126 or changing the colour of blank tasks?
