### PR TITLE
Fix for issue #132 (Default font per OS)

### DIFF
--- a/Client/Controls/MainWindow.xaml.cs
+++ b/Client/Controls/MainWindow.xaml.cs
@@ -96,7 +96,19 @@ namespace Client
 		/// </summary>
 		public void SetFont()
 		{
-			var family = new FontFamily(User.Default.TaskListFontFamily);
+            string FontFamily;
+
+            if (Client.MainWindowViewModel.CheckOSforXP())
+            {
+                FontFamily = User.Default.TaskListFontFamilyXP;
+            }
+            else
+            {
+                FontFamily = User.Default.TaskListFontFamily;
+            }
+
+            var family = new FontFamily(FontFamily);
+
 			double size = User.Default.TaskListFontSize;
 
 			var styleConverter = new FontStyleConverter();

--- a/Client/MainWindowViewModel.cs
+++ b/Client/MainWindowViewModel.cs
@@ -547,7 +547,14 @@ namespace Client
 				User.Default.RequireCtrlEnter = o.cbRequireCtrlEnter.IsChecked.Value;
 
 				// Unfortunately, font classes are not serializable, so all the pieces are tracked instead.
-				User.Default.TaskListFontFamily = o.TaskListFont.Family.ToString();
+                if (CheckOSforXP())
+                {
+                    User.Default.TaskListFontFamilyXP = o.TaskListFont.Family.ToString();
+                }
+                else
+                {
+                    User.Default.TaskListFontFamily = o.TaskListFont.Family.ToString();
+                }
 				User.Default.TaskListFontSize = o.TaskListFont.Size;
 				User.Default.TaskListFontStyle = o.TaskListFont.Style.ToString();
 				User.Default.TaskListFontStretch = o.TaskListFont.Stretch.ToString();
@@ -562,6 +569,24 @@ namespace Client
 				UpdateDisplayedTasks();
 			}
 		}
+
+        // Are we running on XP?  Some of the fonts don't look right on XP, so we need to special case them to something better
+        public static bool CheckOSforXP()
+        {
+            //Get Operating system information.
+            var os = Environment.OSVersion;
+
+            //Get version information about the os.
+            Version vs = os.Version;
+
+            if (os.Platform == PlatformID.Win32NT && vs.Major == 5 && vs.Minor != 0)
+            {
+                // The OS is XP.  
+                return true;
+            }
+            return false;
+        }
+
 
 		public void NewFile()
 		{

--- a/Client/User.Designer.cs
+++ b/Client/User.Designer.cs
@@ -262,7 +262,22 @@ namespace Client {
                 this["TaskListFontFamily"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Verdana")]
+        public string TaskListFontFamilyXP
+        {
+            get
+            {
+                return ((string)(this["TaskListFontFamilyXP"]));
+            }
+            set
+            {
+                this["TaskListFontFamilyXP"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("12")]


### PR DESCRIPTION
Detect whether we're on XP, and if so, default to Verdana instead of
Arial.
From the bug, it looks like we only want to special case the default
font on XP. If we find later we want to do it per-OS, the code in
CheckOSForXP will need to be beefed up to return OS info instead of a
bool as it is currently.
