### PR TITLE
Fix keyboard issues for non-us inputs (issue #130)

### DIFF
--- a/Client/Controls/MainWindow.xaml
+++ b/Client/Controls/MainWindow.xaml
@@ -42,7 +42,7 @@
                 </LinearGradientBrush>
             </Menu.Background>
         </Menu>
-        <TextBox Height="23" Margin="0,23,0,0" Name="taskText" AcceptsReturn="False" Cursor="IBeam" KeyUp="taskText_PreviewKeyUp" VerticalAlignment="Top"/>
+        <TextBox Height="23" Margin="0,23,0,0" Name="taskText" AcceptsReturn="False" Cursor="IBeam" KeyUp="taskText_PreviewKeyUp" TextChanged="taskText_PreviewTextChanged" VerticalAlignment="Top"/>
         <Popup Name="Intellisense" Width="150" Height="auto" StaysOpen="False" Placement="Bottom" IsOpen="False">
             <Grid>
                 <ListBox Name="IntellisenseList"
@@ -55,7 +55,7 @@
             </Grid>
 
         </Popup>
-        <ListBox ItemsSource="{Binding Tasks}" Name="lbTasks" Margin="0,46,0,0" SelectedIndex="0" IsTextSearchEnabled="False" PreviewMouseDoubleClick="lbTasks_PreviewMouseDoubleClick" PreviewKeyUp="lbTasks_PreviewKeyUp" PreviewKeyDown="lbTasks_PreviewKeyDown" AlternationCount="2" BorderBrush="{x:Null}">
+        <ListBox ItemsSource="{Binding Tasks}" Name="lbTasks" Margin="0,46,0,0" SelectedIndex="0" IsTextSearchEnabled="False" PreviewMouseDoubleClick="lbTasks_PreviewMouseDoubleClick" PreviewKeyUp="lbTasks_PreviewKeyUp" PreviewKeyDown="lbTasks_PreviewKeyDown" PreviewTextInput="lbTasks_PreviewTextInput" AlternationCount="2" BorderBrush="{x:Null}">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <StackPanel>

--- a/Client/Controls/MainWindow.xaml.cs
+++ b/Client/Controls/MainWindow.xaml.cs
@@ -309,6 +309,10 @@ namespace Client
 			ViewModel.TaskListKeyUp(Key.U);
         }
 
+        private void lbTasks_PreviewTextInput(object sender, TextCompositionEventArgs e)
+        {
+            ViewModel.TaskListTextInput(e);
+        }
         #endregion
 
 		#region printing
@@ -360,6 +364,11 @@ namespace Client
 		private void taskText_PreviewKeyUp(object sender, KeyEventArgs e)
         {
 			ViewModel.TaskTextPreviewKeyUp(e);
+        }
+
+        private void taskText_PreviewTextChanged(object sender, TextChangedEventArgs e)
+        {
+            ViewModel.TaskTextPreviewTextChanged(e);
         }
 
         #endregion

--- a/Client/MainWindowViewModel.cs
+++ b/Client/MainWindowViewModel.cs
@@ -170,10 +170,6 @@ namespace Client
                     User.Default.Save();
                     break;
 
-                case Key.OemPeriod:
-                    Reload();
-					UpdateDisplayedTasks();
-                    break;
                 case Key.X:
                     ToggleComplete((Task)_window.lbTasks.SelectedItem);
 					UpdateDisplayedTasks();
@@ -252,6 +248,23 @@ namespace Client
                     _window.taskText.Focus();
                     break;
                 default:
+                    break;
+            }
+        }
+
+        public void TaskListTextInput(TextCompositionEventArgs e)
+        {
+            var text = e.Text.ToLowerInvariant();
+
+            switch (text)
+            {
+                case "?":
+                    _window.Help(null, null);
+                    break;
+
+                case ".":
+                    Reload();
+                    UpdateDisplayedTasks();
                     break;
             }
         }
@@ -825,27 +838,33 @@ namespace Client
                         _window.taskText.Text = "";
                         _window.lbTasks.Focus();
                         break;
-                    case Key.OemPlus:
-                    case Key.Add: // handles the '+' from the numpad.
-                        if (e.KeyboardDevice.Modifiers == ModifierKeys.Shift || e.Key == Key.Add) // activates on '+' but not '='.
-                        {
-                            var projects = _taskList.Tasks.SelectMany(task => task.Projects);
-                            _intelliPos = _window.taskText.CaretIndex - 1;
-                            ShowIntellisense(projects.Distinct().OrderBy(s => s), _window.taskText.GetRectFromCharacterIndex(_intelliPos));
-                        }
-                        break;
-                    case Key.D2:
-                        if (e.KeyboardDevice.Modifiers == ModifierKeys.Shift) // activates on '@' but not '2'.
-                        {
-                            var contexts = _taskList.Tasks.SelectMany(task => task.Contexts);
-                            _intelliPos = _window.taskText.CaretIndex - 1;
-                            ShowIntellisense(contexts.Distinct().OrderBy(s => s), _window.taskText.GetRectFromCharacterIndex(_intelliPos));
-                        }
-                        break;
                 }
             }
         }
 
+        public void TaskTextPreviewTextChanged(TextChangedEventArgs e)
+        {
+            if (e.Changes.Count != 1) return;
+            if (e.Changes.First().AddedLength < 1) return;
+            if (_window.taskText.CaretIndex < 1) return;
+
+            var lastAddedCharacter = _window.taskText.Text.Substring(_window.taskText.CaretIndex - 1, 1);
+
+            switch (lastAddedCharacter)
+            {
+                case "+":
+                    var projects = _taskList.Tasks.SelectMany(task => task.Projects);
+                    _intelliPos = _window.taskText.CaretIndex - 1;
+                    ShowIntellisense(projects.Distinct().OrderBy(s => s), _window.taskText.GetRectFromCharacterIndex(_intelliPos));
+                    break;
+
+                case "@":
+                    var contexts = _taskList.Tasks.SelectMany(task => task.Contexts);
+                    _intelliPos = _window.taskText.CaretIndex - 1;
+                    ShowIntellisense(contexts.Distinct().OrderBy(s => s), _window.taskText.GetRectFromCharacterIndex(_intelliPos));
+                    break;
+            }
+        }
 
         /// <summary>
         /// Helper function to determine if the correct keysequence has been entered to create a task.


### PR DESCRIPTION
Hi!

The PR should fix keyboard issues for non-us inputs:

1) @ and + opens the autocompletion boxes regardless of keyboard layout
2) . and ? reloads and opens the help view regardless of keyboard layout

Let me know if I did something wrong in my PR, it's only my second one :)
- Regin
