### PR TITLE
Add "O" as access key in the filter dialog

### DIFF
--- a/Client/Controls/FilterDialog.xaml
+++ b/Client/Controls/FilterDialog.xaml
@@ -20,7 +20,7 @@
         <TextBox AcceptsReturn="True" Height="70" Margin="12,350,12,0" Name="tbFilterPreset3" TextWrapping="Wrap" VerticalAlignment="Top" PreviewKeyUp="tbFilter_PreviewKeyUp" />
         <Button Content="_Clear Active" Margin="12,0,0,1" Name="Clear" Click="Clear_Click" Grid.RowSpan="2" Height="23" VerticalAlignment="Bottom" HorizontalAlignment="Left" Width="75" />
         <Button Content="Clear _All" Height="23" Margin="93,0,0,1" Name="Clear_All" VerticalAlignment="Bottom" Click="Clear_All_Click" Grid.RowSpan="2" HorizontalAlignment="Left" Width="75" />
-        <Button Content="OK" Height="23" HorizontalAlignment="Right" Name="OK" VerticalAlignment="Bottom" Width="75" IsDefault="True" Click="OK_Click" Margin="0,0,93,1" Grid.RowSpan="2" />
+        <Button Content="_OK" Height="23" HorizontalAlignment="Right" Name="OK" VerticalAlignment="Bottom" Width="75" IsDefault="True" Click="OK_Click" Margin="0,0,93,1" Grid.RowSpan="2" />
         <Button Content="Cancel" Height="23" HorizontalAlignment="Right" Margin="0,0,12,1" Name="Cancel" VerticalAlignment="Bottom" Width="75" Click="Cancel_Click" Grid.RowSpan="2" />        
     </Grid>
 </Window>


### PR DESCRIPTION
Another tiny pull request :)

It takes a few "tabs" to get to the "OK" button in the filter dialog, so I've added an access key.
- Regin
