### PR TITLE
Add Font Size Text Box to Font Selection Window (Addresses Issue #157)

### DIFF
--- a/ColorFont/ColorFontChooser.xaml
+++ b/ColorFont/ColorFontChooser.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Original code by Norris Cheng
+<!-- Original code by Norris Cheng
     http://blogs.msdn.com/b/text/archive/2006/06/20/592777.aspx -->
     <UserControl
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -70,12 +70,13 @@
                          TextAlignment="Center" TextWrapping="Wrap" 
                          Text="Lorem ipsum dolor sit amet, consectetur adipisicing elit" Background="#FFFFFFF7"/>
                 <Slider x:Name="fontSizeSlider" 
-                		Maximum="50" Value="10" 
-                        Minimum="8"
-                		SmallChange="0.5" LargeChange="2" HorizontalAlignment="Right" 
+                		Maximum="50"
+                        Minimum="1"
+                		SmallChange="0.5" LargeChange="1" HorizontalAlignment="Right" 
                 		VerticalAlignment="Bottom" Width="192" Margin="0,0,0,5" 
                         TickPlacement="BottomRight" 
-                        AutoToolTipPlacement ="TopLeft" />
+                        AutoToolTipPlacement ="TopLeft" 
+            			Value="{Binding Text, ElementName=fontSizeTextBox, Mode=TwoWay, ValidatesOnExceptions=true}"/>
             </Grid>
             <!-- Color Picker -->
             <Grid Grid.Column="1" Grid.Row="2" Margin="5">
@@ -85,6 +86,18 @@
                 </Grid.RowDefinitions>
                 <TextBlock Grid.Row="0" Margin="0,8,0,0" Text="Font Color:" FontStyle="Italic" Grid.RowSpan="2" />
                 <local:ColorPicker Grid.Row="1" Height="32" x:Name="colorPicker" ColorChanged="colorPicker_ColorChanged" Margin="0,2"  />
+            </Grid>
+        	
+        	<!-- Font Size -->
+            <Grid Grid.Column="2" Grid.Row="2" Margin="5">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="24" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <TextBlock Grid.Row="0" Margin="0,8,0,0" Text="Font Size:" FontStyle="Italic" Grid.RowSpan="2" />
+                <TextBox Name="fontSizeTextBox" 
+                         Text="{Binding Value, ElementName=fontSizeSlider, Mode=TwoWay, ValidatesOnExceptions=true, FallbackValue=10.0}" 
+                         Grid.Row="1" Height="32" Margin="0,2" />
             </Grid>
         </Grid>
     </Grid>


### PR DESCRIPTION
This change addresses and potentially closes Issue #157 (Font size show
as float number).

I added a text field for font size into the font selection dialog. The
font size text box is bound to the slider in a two-way sync. With this
setup, the user can see and edit the exact font size in the text box,
and still use the slider to set fonts, and still have no restrictions on
the float value of the font size. This would address issue #157 because
the exact font size displayed and set in the font selection window would
now reflected in the options window. It also makes it easier to set
integer-value font sizes.

I also changed the slider's "big jump" value from 2 to 1 to make it
simpler to move the slider up and down by one point (by clicking on the
line). Lastly, I changed the slider minimum from 8 to 1 because the
minimum of 8 made the font size text box reject the first digit in font
sizes such as "12" and "25" because the first number was less than 8.
