### PR TITLE
Closes Issue #218: Feature: Do not remove empty lines

### DIFF
--- a/Client/Controls/Options.xaml
+++ b/Client/Controls/Options.xaml
@@ -22,6 +22,6 @@
         <Button Content="Select Font..." Height="23" HorizontalAlignment="Left" Margin="415,75,0,0" Name="selectFonts" VerticalAlignment="Top" Width="75" Click="selectFonts_Click" />
         <Label Content="Current Font" Height="28" HorizontalAlignment="Left" Margin="25,73,0,0" Name="label2" VerticalAlignment="Top" />
         <TextBox Height="22" HorizontalAlignment="Right" Margin="0,74,96,0" Name="currentFontDisplay" VerticalAlignment="Top" Width="304" IsUndoEnabled="False" IsReadOnly="True" />
-        <CheckBox Content="Preserve Leading Whitespace" Height="16" HorizontalAlignment="Left" Margin="25,311,0,0" Name="cbPreserveWhiteSpace" VerticalAlignment="Top" Width="203" />
+        <CheckBox Content="Preserve Leading Whitespace and Blank Lines" Height="16" HorizontalAlignment="Left" Margin="25,311,0,0" Name="cbPreserveWhiteSpace" VerticalAlignment="Top" Width="273" />
     </Grid>
 </Window>

--- a/Client/MainWindowViewModel.cs
+++ b/Client/MainWindowViewModel.cs
@@ -68,6 +68,8 @@ namespace Client
 
             SortType = (SortType)User.Default.CurrentSort;
 
+            TaskList.pbPreserveWhiteSpace = User.Default.PreserveWhiteSpace;
+
             if (!string.IsNullOrEmpty(User.Default.FilePath))
             {
                 LoadTasks(User.Default.FilePath);
@@ -1145,6 +1147,7 @@ namespace Client
             User.Default.RequireCtrlEnter = o.cbRequireCtrlEnter.IsChecked.Value;
             User.Default.AllowGrouping = o.cbAllowGrouping.IsChecked.Value;
             User.Default.PreserveWhiteSpace = o.cbPreserveWhiteSpace.IsChecked.Value;
+            TaskList.pbPreserveWhiteSpace = User.Default.PreserveWhiteSpace; 
 
             // Unfortunately, font classes are not serializable, so all the pieces are tracked instead.
             User.Default.TaskListFontFamily = o.TaskListFont.Family.ToString();

--- a/ToDoLib/TaskList.cs
+++ b/ToDoLib/TaskList.cs
@@ -24,6 +24,19 @@ namespace ToDoLib
 
 		public List<Task> Tasks { get; private set; }
 
+        static private bool _pbPreserveWhiteSpace = false; 
+        static public bool pbPreserveWhiteSpace
+        {
+            get
+            {
+                return _pbPreserveWhiteSpace;
+            }
+            set
+            {
+                _pbPreserveWhiteSpace = value;
+            }
+        }
+
 		public TaskList(string filePath)
 		{
 			_filePath = filePath;
@@ -45,7 +58,7 @@ namespace ToDoLib
 					string raw;
 					while ((raw = reader.ReadLine()) != null) 
 					{
-						if (!raw.IsNullOrEmpty())
+						if (!raw.IsNullOrEmpty() || pbPreserveWhiteSpace)
                         {
                             Tasks.Add(new Task(raw));
                         }                            


### PR DESCRIPTION
Piggy backs the flag for preserving white space.  If set, blank lines
will be read from the todo.txt file and added to the task list.
