### PR TITLE
Improved regex for context and project

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,27 +29,27 @@ Please send your pull requests to the 'dev' branch. If you forget it's not a maj
  - Intellisense for projects and contexts
  - Minimize to tray icon - double-click the icon or Win-Alt-T to hide or show the app
  - Keyboard shortcuts:
-	- O or Ctrl+O: open todo.txt file
-	- C or Ctrl+N: new todo.txt file
-	- N: new task
-	- J: next task
-	- K: prev task
-	- X: toggle task completion
-	- A: archive tasks
-	- D or Del or Backspace: delete task (with confirmation)
-	- U or F2: update task
+    - O or Ctrl+O: open todo.txt file
+    - C or Ctrl+N: new todo.txt file
+    - N: new task
+    - J: next task
+    - K: prev task
+    - X: toggle task completion
+    - A: archive tasks
+    - D or Del or Backspace: delete task (with confirmation)
+    - U or F2: update task
     - T: append text to selected tasks
-	- F: filter tasks (free-text, one filter condition per line)
+    - F: filter tasks (free-text, one filter condition per line)
     - 0: clear filter
     - 1-9: apply numbered filter preset
-	- . or F5: reload tasks from file
-	- ?: show help
-	- Alt+Up: increase priority
-	- Alt+Down: decrease priority
-	- Alt+Left/Right: clear priority
- 	- Ctrl+Alt+Up: increase due date by 1 day
-	- Ctrl+Alt+Down: decrease due date by 1 day
+    - . or F5: reload tasks from file
+    - ?: show help
+    - Alt+Up: increase priority
+    - Alt+Down: decrease priority
+    - Alt+Left/Right: clear priority
+    - Ctrl+Alt+Up: increase due date by 1 day
+    - Ctrl+Alt+Down: decrease due date by 1 day
     - Ctrl+Alt+Left/Right: remove due date 
-	- Ctrl+C: copy task to clipboard
-	- Ctrl+Shift+C: copy task to edit field
-	- Win+Alt+T: hide/unhide windows
+    - Ctrl+C: copy task to clipboard
+    - Ctrl+Shift+C: copy task to edit field
+    - Win+Alt+T: hide/unhide windows

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### todotxt.net
 
-This is an implemention of [todo.txt](http://todotxt.com/) using the .NET framework. As far as I am aware, it is fully complient with [Gina's spec](https://github.com/ginatrapani/todo.txt-cli/wiki/The-Todo.txt-Format). 
+This is an implemention of [todo.txt](http://todotxt.com/) using the .NET framework. As far as I am aware, it is fully compliant with [Gina's spec](https://github.com/ginatrapani/todo.txt-cli/wiki/The-Todo.txt-Format). 
 
 There is installer for the latest version available from the [the main site](http://benrhughes.github.io/todotxt.net/).
 

--- a/ToDoLib/Task.cs
+++ b/ToDoLib/Task.cs
@@ -24,7 +24,7 @@ namespace ToDoLib
             @"due:(?<dateRelative>today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday)";
 
         private const string DueDatePattern = @"due:(?<date>(\d{4})-(\d{2})-(\d{2}))";
-        private const string ProjectPattern = @"(?<proj>(?<=^|\s)\+[^\s]+)";
+        private const string ProjectPattern = @"(?<proj>(?<=^|\s)\+[\w\-_]+)";
         private const string ContextPattern = @"(^|\s)(?<context>\@[^\s]+)";
 
         public List<string> Projects { get; set; }

--- a/ToDoLib/Task.cs
+++ b/ToDoLib/Task.cs
@@ -25,7 +25,7 @@ namespace ToDoLib
 
         private const string DueDatePattern = @"due:(?<date>(\d{4})-(\d{2})-(\d{2}))";
         private const string ProjectPattern = @"(?<proj>(?<=^|\s)\+[\w\-_]+)";
-        private const string ContextPattern = @"(^|\s)(?<context>\@[^\s]+)";
+        private const string ContextPattern = @"(^|\s)(?<context>\@[\w\-_]+)";
 
         public List<string> Projects { get; set; }
         public string PrimaryProject { get; private set; }

--- a/ToDoLib/Task.cs
+++ b/ToDoLib/Task.cs
@@ -24,8 +24,8 @@ namespace ToDoLib
             @"due:(?<dateRelative>today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday)";
 
         private const string DueDatePattern = @"due:(?<date>(\d{4})-(\d{2})-(\d{2}))";
-        private const string ProjectPattern = @"(?<proj>(?<=^|\s)\+[\w\-_]+)";
-        private const string ContextPattern = @"(^|\s)(?<context>\@[\w\-_]+)";
+        private const string ProjectPattern = @"(?<proj>(?<=^|\W)\+[\w]+)";
+        private const string ContextPattern = @"(^|\W)(?<context>\@[\w]+)";
 
         public List<string> Projects { get; set; }
         public string PrimaryProject { get; private set; }


### PR DESCRIPTION
List items like this:
`Pay +bills. @phone, (@home?); @PC? (+money_woes)`
ended up with contexts
- `@phone.`
- `@home?);`
- `@PC?`

and projects
- `+bills.`
- `+money_woes)`

I think it's more intuitive that tasks `Call bank @phone` and `Call bank @phone.` have the same context: `@phone`.

Don't see this in the issues list, so perhaps it's just me, but thought I'd offer this back upstream.