### PR TITLE
Add an option to check for updates on startup

### DIFF
--- a/Client/Controls/MainWindow.xaml.cs
+++ b/Client/Controls/MainWindow.xaml.cs
@@ -30,7 +30,7 @@ namespace Client
 
 			SetupTrayIcon();
 
-			CheckForUpdates();
+			if (User.Default.CheckForUpdates) CheckForUpdates();
 
 			webBrowser1.Navigate("about:blank");
 
@@ -122,7 +122,7 @@ namespace Client
 		public void ToggleUpdateMenu(string version)
         {
             var assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-            if (version != assemblyVersion)
+            if (!string.IsNullOrEmpty(version) && version != assemblyVersion)
             {
 				UpdateMenu.Header = "New version: " + version;
 				UpdateMenu.Visibility = Visibility.Visible;

--- a/Client/Controls/Options.xaml
+++ b/Client/Controls/Options.xaml
@@ -52,6 +52,7 @@
             <CheckBox Content="Preserve leading whitespace and blank lines" x:Name="cbPreserveWhiteSpace"  />
             <CheckBox Content="Apply word wrap to task list" x:Name="cbWordWrap"  />
             <CheckBox Content="Display status bar" x:Name="cbDisplayStatusBar" />
+            <CheckBox Content="Check for updates on startup" x:Name="cbCheckForUpdates" />
         </StackPanel>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
             <Button Content="Cancel" Name="Cancel" Click="Cancel_Click" IsCancel="True" Margin="0,0,7,0"/>

--- a/Client/Controls/Options.xaml.cs
+++ b/Client/Controls/Options.xaml.cs
@@ -40,6 +40,7 @@ namespace Client
             cbWordWrap.IsChecked = User.Default.WordWrap;
             this.TaskListFont = taskFont;
             this.cbDisplayStatusBar.IsChecked = User.Default.DisplayStatusBar;
+            this.cbCheckForUpdates.IsChecked = User.Default.CheckForUpdates;
         }
 
         private FontInfo taskListFont;

--- a/Client/MainWindowViewModel.cs
+++ b/Client/MainWindowViewModel.cs
@@ -1494,6 +1494,7 @@ namespace Client
             User.Default.TaskListFontBrushColor = o.TaskListFont.BrushColor.ToString();
 
             User.Default.DisplayStatusBar = o.cbDisplayStatusBar.IsChecked.Value;
+            User.Default.CheckForUpdates = o.cbCheckForUpdates.IsChecked.Value;
 
             User.Default.Save();
 

--- a/Client/User.Designer.cs
+++ b/Client/User.Designer.cs
@@ -490,5 +490,16 @@ namespace Client {
                 this["ShowHidenTasks"] = value;
             }
         }
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool CheckForUpdates {
+            get {
+                return ((bool)(this["CheckForUpdates"]));
+            }
+            set {
+                this["CheckForUpdates"] = value;
+            }
+        }
     }
 }

--- a/Client/User.settings
+++ b/Client/User.settings
@@ -119,5 +119,8 @@
     <Setting Name="ShowHidenTasks" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="CheckForUpdates" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Client/app.config
+++ b/Client/app.config
@@ -124,6 +124,9 @@
             <setting name="ShowHidenTasks" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="CheckForUpdates" serializeAs="String">
+                <value>True</value>
+            </setting>
         </Client.User>
     </userSettings>
 </configuration>


### PR DESCRIPTION
Added an option to disable checking for updates so if todotxt.net is unable to access the Internet, the user can disable update checking on startup to prevent constantly having "New version" showing in the menu.