### PR TITLE
Fix order of ok and cancel buttons

### DIFF
--- a/Client/Controls/FilterDialog.xaml
+++ b/Client/Controls/FilterDialog.xaml
@@ -66,8 +66,8 @@
             </Grid.ColumnDefinitions>
             <Button Grid.Row="0" Grid.Column="0" Content="_Clear Active" HorizontalAlignment="Left" Name="Clear" Click="Clear_Click" />
             <Button Grid.Row="0" Grid.Column="1" Content="Clear _All" HorizontalAlignment="Left" Name="Clear_All" Click="Clear_All_Click" />
-            <Button Grid.Row="0" Grid.Column="3" Content="Cancel" HorizontalAlignment="Right" Name="Cancel" Click="Cancel_Click" />
-            <Button Grid.Row="0" Grid.Column="4" Content="_OK" HorizontalAlignment="Right" Name="OK" IsDefault="True" Click="OK_Click"  />
+            <Button Grid.Row="0" Grid.Column="3" Content="_OK" HorizontalAlignment="Right" Name="OK" IsDefault="True" Click="OK_Click"  />
+            <Button Grid.Row="0" Grid.Column="4" Content="Cancel" HorizontalAlignment="Right" Name="Cancel" Click="Cancel_Click" />
         </Grid>
     </StackPanel>    
 </Window>

--- a/Client/Controls/Options.xaml
+++ b/Client/Controls/Options.xaml
@@ -55,8 +55,8 @@
             <CheckBox Content="Check for updates on startup" x:Name="cbCheckForUpdates" />
         </StackPanel>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Content="Cancel" Name="Cancel" Click="Cancel_Click" IsCancel="True" Margin="0,0,7,0"/>
-            <Button Content="OK" Name="OK" VerticalAlignment="Bottom" IsDefault="True" Click="OK_Click" />
+            <Button Content="OK" Name="OK" IsDefault="True" Click="OK_Click" Margin="0,0,7,0" />
+            <Button Content="Cancel" Name="Cancel" IsCancel="True" Click="Cancel_Click" />
         </StackPanel>
     </StackPanel>
 </Window>


### PR DESCRIPTION
This commit makes the order of the ok and cancel buttons in the settings- and filter-dialog windows standard conform. The ok-button should be left, cancel-button should be right.