### PR TITLE
Global portable settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ packages/
 *.iml
 .vs
 _ReSharper*
+*.sln.Dotsettings
 
 # linux
 *~

--- a/Client/PortableSettingsProvider.cs
+++ b/Client/PortableSettingsProvider.cs
@@ -22,7 +22,7 @@ namespace Client
             get
             {
                 return Path.Combine(Path.GetDirectoryName(Application.ExecutablePath),
-                   string.Format("{0}.settings", ApplicationName));
+                    string.Format("{0}.settings", ApplicationName));
             }
         }
 
@@ -43,15 +43,9 @@ namespace Client
             }
         }
 
-        private XmlNode _globalSettingsNode
-        {
-            get { return GetSettingsNode(_globalSettingsNodeName); }
-        }
+        private XmlNode _globalSettingsNode => GetSettingsNode(_globalSettingsNodeName);
 
-        private XmlNode _rootNode
-        {
-            get { return _rootDocument.SelectSingleNode(_rootNodeName); }
-        }
+        private XmlNode _rootNode => _rootDocument.SelectSingleNode(_rootNodeName);
 
         private XmlDocument _rootDocument
         {
@@ -132,9 +126,7 @@ namespace Client
 
         private void SetValue(SettingsPropertyValue propertyValue)
         {
-            XmlNode targetNode = IsGlobal(propertyValue.Property)
-               ? _globalSettingsNode
-               : _localSettingsNode;
+            XmlNode targetNode = _globalSettingsNode;
 
             XmlNode settingNode = targetNode.SelectSingleNode(string.Format("setting[@name='{0}']", propertyValue.Name));
 
@@ -156,7 +148,7 @@ namespace Client
 
         private string GetValue(SettingsProperty property)
         {
-            XmlNode targetNode = IsGlobal(property) ? _globalSettingsNode : _localSettingsNode;
+            XmlNode targetNode = _globalSettingsNode;
             XmlNode settingNode = targetNode.SelectSingleNode(string.Format("setting[@name='{0}']", property.Name));
 
             if (settingNode == null)
@@ -200,7 +192,6 @@ namespace Client
 
         public void Reset(SettingsContext context)
         {
-            _localSettingsNode.RemoveAll();
             _globalSettingsNode.RemoveAll();
 
             _xmlDocument.Save(_filePath);

--- a/ToDo.Net.sln.DotSettings
+++ b/ToDo.Net.sln.DotSettings
@@ -1,7 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_FIXED_BRACES_STYLE/@EntryValue">ONLY_FOR_MULTILINE</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_FOR_BRACES_STYLE/@EntryValue">ONLY_FOR_MULTILINE</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_FOREACH_BRACES_STYLE/@EntryValue">ONLY_FOR_MULTILINE</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_USING_BRACES_STYLE/@EntryValue">ONLY_FOR_MULTILINE</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_WHILE_BRACES_STYLE/@EntryValue">ONLY_FOR_MULTILINE</s:String>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Currently, when built as portable, the app saves user configurations in `todotxt.settings` file in the same directory where `todotxt.exe` is. However, the configurations are saved as *"local"* under a key based on hostname of a machine. With this behavior, users lose their app configurations when they move to another machine (e.g. via online synchronization services), which to me doesn't make a lot of sense for a "portable" application. 
With this change, the portable version of the app will save user configurations under a *"global"* session in the settings file. (**Users need to manually migrate old settings.**)

Let me know how you think. And thanks for the great app!
