### PR TITLE
Minor README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-### todotxt.net
+# todotxt.net
 
 This is an implemention of [todo.txt](http://todotxt.com/) using the .NET framework. As far as I am aware, it is fully compliant with [Gina's spec](https://github.com/ginatrapani/todo.txt-cli/wiki/The-Todo.txt-Format). 
 
 There is installer for the latest version available from the [release page](https://github.com/benrhughes/todotxt.net/releases).
 
-#### Maintenence mode
+## Maintenence mode
 
 Please note that todotxt.net is now in maintenence mode. I'm am happy to receive bug reports and bug fixes, but no new features will be added at this stage.
 
-#### Contributors please note
+## Note for contributors
 
 If you change any of the ToDoLib files, please make sure the current unit tests pass, and add new tests where appropriate.
 
 Please send your pull requests to the 'dev' branch. 
 
-#### Goals
+## Goals
 
  - menu driven interface for novices
  - minimalist, keyboard-driven UI for expert users
@@ -24,7 +24,7 @@ Please send your pull requests to the 'dev' branch.
  - full compliance with Gina's specs
 
 
-#### Current features:
+## Features
 
  - Sorting by completed status, priority, project, context, alphabetically due date or the order in the file
  - Sorting respects multiple projects and contexts

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ There is installer for the latest version available from the [releases page](htt
 
 ## Maintenence mode
 
-Please note that todotxt.net is now in maintenence mode. I'm am happy to receive bug reports and bug fixes, but no new features will be added at this stage.
+Please note that todotxt.net is now in maintenence mode. I am happy to receive bug reports and bug fixes, but no new features will be added at this stage.
 
 ## Note for contributors
 
-If you change any of the ToDoLib files, please make sure the current unit tests pass, and add new tests where appropriate.
+If you change any of the files in the [`ToDoLib`](ToDoLib) folder, please make sure the current unit tests pass, and add new tests where appropriate.
 
-Please send your pull requests to the 'dev' branch. 
+Please send your pull requests to the `dev` branch. 
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # todotxt.net
 
-This is an implemention of [todo.txt](http://todotxt.com/) using the .NET framework. As far as I am aware, it is fully compliant with [Gina's spec](https://github.com/ginatrapani/todo.txt-cli/wiki/The-Todo.txt-Format). 
+This is an implemention of [todo.txt](http://todotxt.org/) using the .NET framework. As far as I am aware, it is fully compliant with [Gina's spec](https://github.com/todotxt/todo.txt/blob/master/README.md). 
 
-There is installer for the latest version available from the [release page](https://github.com/benrhughes/todotxt.net/releases).
+There is installer for the latest version available from the [releases page](https://github.com/benrhughes/todotxt.net/releases).
 
 ## Maintenence mode
 


### PR DESCRIPTION
If there's anything else you think I missed or you don't want changed, don't hesitate to say so.

## Changelog
### README.md
- Markdown syntax fixes (commit c85e2b7292d28c5d76c47fef372f3fa4f5d1bea4)
  - Correct heading levels
  - Remove a random colon
- Correct links (commit bdce7af166eab08f578a6ab520db90881c00710c)
  - todotxt.com redirected to todotxt.org
  - The specification got moved to it's own repository on GitHub
- Minor fixes  (commit b5e57fd26233d546ebea02b6eb0ce87593ef7fdb)
  - Convert some of the 'single quotes' to `in-line code blocks` (backticks)
  - Link to the "ToDoLib" folder
  - Correct typo ("I'm am happy" to "I am happy")